### PR TITLE
Add basic docs and fix README paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables
+OPENAI_API_KEY=your-openai-key
+ANTHROPIC_API_KEY=your-anthropic-key
+WORLD_INTERFACE_KEY=your-cli-key

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ cp config.example.yaml config.yaml
 2. Run a simple conversation:
 
 ```bash
-python orchestrator.py --models gpt-4-turbo claude-sonnet --turns 5
+python main.py --models gpt-4-turbo claude-sonnet --turns 5
 ```
 
 3. Include a human in the conversation:
 
 ```bash
-python orchestrator.py --models gpt-4-turbo claude-sonnet human-participant --turns 3
+python main.py --models gpt-4-turbo claude-sonnet human-participant --turns 3
 ```
 
 ## Configuration
@@ -104,21 +104,21 @@ The role system allows you to create specialized AI participants:
 
 ```bash
 # Use summarization for managing long conversations
-python orchestrator.py --models gpt-4-turbo claude-sonnet --token-strategy SUMMARIZE
+python main.py --models gpt-4-turbo claude-sonnet --token-strategy SUMMARIZE
 ```
 
 ### Custom Roles
 
 ```bash
 # Define and use models with custom roles
-python orchestrator.py --models creative-gpt logical-claude mediator-claude
+python main.py --models creative-gpt logical-claude mediator-claude
 ```
 
 ### Saving and Analyzing Conversations
 
 ```bash
 # Specify a custom log folder
-python orchestrator.py --log-folder ./my_conversations
+python main.py --log-folder ./my_conversations
 ```
 
 ## API Reference

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,84 @@
+# AI Orchestrator Configuration
+
+# Model configurations
+models:
+  gpt-4-turbo:
+    provider: OPENAI
+    api_name: gpt-4-turbo-preview
+    role: PRIMARY
+    temperature: 0.8
+    max_response_tokens: 2048
+    max_context_tokens: 128000
+    token_limit_strategy: SLIDING_WINDOW
+    system_prompt: |
+      You are a helpful, harmless, and honest AI assistant. Your goal is to provide
+      accurate and informative responses to help users with their questions.
+    custom_parameters:
+      top_p: 0.95
+      presence_penalty: 0.1
+      frequency_penalty: 0.1
+
+  claude-sonnet:
+    provider: ANTHROPIC
+    api_name: claude-3-sonnet-20240229
+    role: CRITIC
+    temperature: 0.7
+    max_response_tokens: 4096
+    max_context_tokens: 200000
+    token_limit_strategy: SUMMARIZE
+    system_prompt: |
+      You are a thoughtful critic and analyst. Your role is to carefully evaluate
+      arguments, identify potential issues, and suggest improvements. You are
+      not argumentative, but rather constructive in your feedback.
+
+  creative-gpt:
+    provider: OPENAI
+    api_name: gpt-4
+    role: CREATIVE
+    temperature: 1.0
+    max_response_tokens: 1024
+    max_context_tokens: 8192
+    token_limit_strategy: TRUNCATE_OLDEST
+    system_prompt: |
+      You are a creative assistant focused on generating original ideas and
+      solutions. Think outside the box and offer innovative perspectives.
+
+  logical-claude:
+    provider: ANTHROPIC
+    api_name: claude-3-opus-20240229
+    role: LOGICAL
+    temperature: 0.5
+    max_response_tokens: 2048
+    max_context_tokens: 100000
+    token_limit_strategy: TRUNCATE_OLDEST
+    system_prompt: |
+      You are a logical, analytical assistant. Your responses should be focused on
+      factual accuracy, sound reasoning, and logical consistency. Avoid speculation
+      and be clear about uncertainties.
+
+  human-participant:
+    provider: HUMAN
+    role: PRIMARY
+    system_prompt: "Human participant in the conversation."
+
+# Orchestration settings
+orchestration:
+  default_max_turns: 10
+  auto_summarize: true
+  summary_interval: 5
+  allow_human_intervention: true
+  intervention_probability: 0.2
+  default_models:
+    - gpt-4-turbo
+    - claude-sonnet
+    - human-participant
+
+# Logging settings
+logging:
+  log_level: INFO
+  console_output: true
+  file_output: true
+  rich_formatting: true
+  save_media: true
+  metrics_tracking: true
+  anonymize_data: false

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,23 @@
+# API Overview
+
+This project exposes a small set of classes that coordinate multi-model conversations.
+
+## AIOrchestrator
+High level interface that manages the conversation loop. It loads configuration, initializes models, and coordinates response generation and logging.
+
+## ModelRegistry
+Loads model definitions from the configuration file and initializes API clients for each provider.
+
+## ResponseGenerator
+Handles calling the underlying model APIs (OpenAI, Anthropic, CLI or human input) to generate responses based on the conversation history.
+
+## ConversationMemory
+Stores messages exchanged during the conversation and applies token limit strategies such as truncation or summarization when the history grows too large.
+
+## ConfigurationManager
+Reads the YAML configuration, providing access to model, orchestration and logging sections.
+
+## ConversationLogger
+Writes conversation transcripts to plain text and JSON log files for later analysis.
+
+These classes are defined in `main.py` and are intended to be composed by `AIOrchestrator` when running a chat session.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,39 @@
+# Configuration Guide
+
+The AI Orchestrator is configured with a YAML file. The configuration is divided into sections described below.
+
+## Models
+Define each model under the `models` key. Common fields for a model configuration are:
+
+- `provider` – one of `OPENAI`, `ANTHROPIC`, `CLI`, or `HUMAN`.
+- `api_name` – the model identifier used by the provider.
+- `role` – conversation role such as `PRIMARY`, `CRITIC`, `SUMMARIZER`, `MEDIATOR`, `CREATIVE`, `LOGICAL`, or `CUSTOM`.
+- `temperature` – randomness of the responses.
+- `max_response_tokens` – maximum tokens to generate for each response.
+- `max_context_tokens` – total tokens allowed in the conversation history for the model.
+- `token_limit_strategy` – how to handle long conversations; options are `TRUNCATE_OLDEST`, `SUMMARIZE`, or `SLIDING_WINDOW`.
+- `system_prompt` – default system prompt for the model.
+- `custom_parameters` – provider specific options passed directly to the API.
+
+## Orchestration
+Settings related to the conversation as a whole are placed under `orchestration`:
+
+- `default_max_turns` – number of turns before the orchestrator stops.
+- `auto_summarize` – whether to periodically summarize the conversation.
+- `summary_interval` – number of turns between summaries.
+- `allow_human_intervention` – if a human participant can interject.
+- `intervention_probability` – probability of human intervention when enabled.
+- `default_models` – list of model names used when no models are specified on the command line.
+
+## Logging
+Control log output under `logging`:
+
+- `log_level` – logging verbosity (`INFO`, `DEBUG`, etc.).
+- `console_output` – enable colored console output.
+- `file_output` – write plain text logs to disk.
+- `rich_formatting` – store logs with rich formatting.
+- `save_media` – preserve any media attachments.
+- `metrics_tracking` – record basic metrics about the run.
+- `anonymize_data` – remove personal information from logs.
+
+Use the example configuration file (`config.example.yaml`) as a starting point and modify the fields that apply to your setup.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+openai
+anthropic
+python-dotenv
+rich
+tiktoken
+pyyaml
+requests
+pydantic


### PR DESCRIPTION
## Summary
- add documentation for configuration and API classes
- provide sample environment file and example config
- include requirements.txt so setup instructions work
- update README links and script references

## Testing
- `python -m py_compile main.py`
- `python main.py --models gpt-4-turbo claude-sonnet --turns 0` *(fails: No module named 'openai')*
- `pip install --no-cache-dir -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai)*