### PR TITLE
Move dotenv loading to main and document env keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment variables for AI Orchestrator
+# Copy this file to .env and replace the placeholders with your own keys
+
+# OpenAI API key
+OPENAI_API_KEY=
+
+# Anthropic API key
+ANTHROPIC_API_KEY=
+
+# Optional key used by the world interface
+WORLD_INTERFACE_KEY=

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ pip install -r requirements.txt
 
 # Set up environment variables
 cp .env.example .env
-# Edit .env with your API keys
+# Edit `.env` and provide the required keys:
+
+```
+OPENAI_API_KEY=<your OpenAI API key>
+ANTHROPIC_API_KEY=<your Anthropic API key>
+# Optional key used when interacting with the world interface
+WORLD_INTERFACE_KEY=<your world interface key>
 ```
 
 ### Requirements

--- a/main.py
+++ b/main.py
@@ -309,7 +309,6 @@ class ConfigurationManager:
 class ModelRegistry:
     """Registry for AI models with initialization of clients."""
     def __init__(self, config_manager: ConfigurationManager):
-        load_dotenv()
         self.config_manager = config_manager
         self.models: Dict[str, ModelConfig] = {}
         self._initialize_models()
@@ -683,7 +682,10 @@ async def main():
     parser.add_argument("--list-models", action="store_true", help="List available models and exit")
     
     args = parser.parse_args()
-    
+
+    # Load environment variables before initializing the registry
+    load_dotenv()
+
     # Create orchestrator
     orchestrator = AIOrchestrator(
         models=args.models,


### PR DESCRIPTION
## Summary
- load environment variables in `main()` before creating the `ModelRegistry`
- remove `load_dotenv()` from `ModelRegistry.__init__`
- add sample `.env.example` file
- describe required environment variables in `README`

## Testing
- `python -m py_compile main.py`