### PR TITLE
Add basic unit tests and pytest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ The AI Orchestrator exposes several key classes:
 
 For full API documentation, see the [API reference](docs/api.md).
 
+## Running Tests
+
+The project uses [pytest](https://pytest.org/) for unit tests. To execute the
+test suite, simply run:
+
+```bash
+pytest
+```
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import sys
+from types import SimpleNamespace
+
+class DummyEncoder:
+    def encode(self, text):
+        # simplistic tokenization by splitting on whitespace
+        return text.split()
+
+def _dummy_client(*args, **kwargs):
+    return SimpleNamespace()
+
+sys.modules.setdefault("openai", SimpleNamespace(OpenAI=_dummy_client))
+sys.modules.setdefault("anthropic", SimpleNamespace(Client=_dummy_client))
+sys.modules.setdefault("tiktoken", SimpleNamespace(get_encoding=lambda name='cl100k_base': DummyEncoder()))

--- a/tests/test_conversation_memory.py
+++ b/tests/test_conversation_memory.py
@@ -1,0 +1,54 @@
+# import main after dummy modules have been set in conftest
+import main
+
+Message = main.Message
+MessageContent = main.MessageContent
+ConversationMemory = main.ConversationMemory
+TokenLimitStrategy = main.TokenLimitStrategy
+
+
+def create_message(text):
+    return Message(role="user", content=text)
+
+
+def test_truncate_oldest_strategy():
+    mem = ConversationMemory(max_tokens=10, strategy=TokenLimitStrategy.TRUNCATE_OLDEST)
+    mem.add_message(create_message("one two three four five six seven eight"))  # 8 tokens
+    mem.add_message(create_message("nine ten eleven twelve thirteen fourteen"))  # 6 tokens
+    # After exceeding limit, oldest message should be removed
+    assert len(mem.get_messages()) == 1
+    assert mem.get_messages()[0].content.text.startswith("nine")
+
+
+def test_summarize_strategy_invoked(monkeypatch):
+    called = {}
+
+    def fake_summarize(self):
+        called['summarize'] = True
+        # mimic original behaviour
+        ConversationMemory._truncate_oldest(self)
+
+    mem = ConversationMemory(max_tokens=10, strategy=TokenLimitStrategy.SUMMARIZE)
+    monkeypatch.setattr(ConversationMemory, "_summarize_conversation", fake_summarize)
+
+    mem.add_message(create_message("one two three four five six seven eight"))
+    mem.add_message(create_message("nine ten eleven twelve thirteen fourteen"))
+
+    assert called.get('summarize', False)
+
+
+def test_sliding_window_strategy_invoked(monkeypatch):
+    called = {}
+
+    def fake_window(self):
+        called['window'] = True
+        ConversationMemory._truncate_oldest(self)
+
+    mem = ConversationMemory(max_tokens=10, strategy=TokenLimitStrategy.SLIDING_WINDOW)
+    monkeypatch.setattr(ConversationMemory, "_apply_sliding_window", fake_window)
+
+    mem.add_message(create_message("one two three four five six seven eight"))
+    mem.add_message(create_message("nine ten eleven twelve thirteen fourteen"))
+
+    assert called.get('window', False)
+

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,26 @@
+import main
+
+class DummyConfig:
+    def get_model_configs(self):
+        return {}
+
+
+def test_registry_with_api_keys(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "key1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "key2")
+    registry = main.ModelRegistry(DummyConfig())
+    models = registry.list_available_models()
+    assert "gpt-4" in models
+    assert "claude-3" in models
+    assert "human" in models
+
+
+def test_registry_without_api_keys(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    registry = main.ModelRegistry(DummyConfig())
+    models = registry.list_available_models()
+    assert "gpt-4" not in models
+    assert "claude-3" not in models
+    assert "human" in models
+


### PR DESCRIPTION
## Summary
- add pytest fixtures and two unit test modules covering `ConversationMemory` and `ModelRegistry`
- document how to run the tests in the README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*