### PR TITLE
Improve ResponseGenerator error handling

### DIFF
--- a/response_generator.py
+++ b/response_generator.py
@@ -1,9 +1,18 @@
 """Generate responses from various AI providers."""
 import asyncio
 import os
-import requests
 import logging
 from typing import Optional
+import requests
+
+try:  # optional dependency during tests
+    from openai import OpenAIError, RateLimitError
+except Exception:  # pragma: no cover - fallback when openai not installed
+    class OpenAIError(Exception):
+        """Fallback OpenAI base error."""
+
+    class RateLimitError(OpenAIError):
+        """Fallback error for rate limiting."""
 
 from rich.prompt import Prompt
 
@@ -15,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 class ResponseGenerator:
     """Generates responses from AI models."""
+
+    MAX_RETRIES = 3
 
     def __init__(self, registry: ModelRegistry) -> None:
         self.registry = registry
@@ -54,21 +65,34 @@ class ResponseGenerator:
         conversation_memory: ConversationMemory,
         system_prompt: str,
     ) -> str:
-        try:
-            messages = [{"role": "system", "content": system_prompt}]
-            messages.extend(conversation_memory.get_formatted_messages())
-            response = await asyncio.to_thread(
-                model_config.client.chat.completions.create,
-                model=model_config.api_name,
-                messages=messages,
-                temperature=model_config.temperature,
-                max_tokens=model_config.max_response_tokens,
-                **model_config.custom_parameters,
-            )
-            return response.choices[0].message.content
-        except Exception as e:
-            logger.error("Error generating OpenAI response: %s", e)
-            return f"[Error generating response: {e}]"
+        messages = [{"role": "system", "content": system_prompt}]
+        messages.extend(conversation_memory.get_formatted_messages())
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                response = await asyncio.to_thread(
+                    model_config.client.chat.completions.create,
+                    model=model_config.api_name,
+                    messages=messages,
+                    temperature=model_config.temperature,
+                    max_tokens=model_config.max_response_tokens,
+                    **model_config.custom_parameters,
+                )
+                return response.choices[0].message.content
+            except RateLimitError as e:
+                wait = 2 ** attempt
+                logger.warning(
+                    "OpenAI rate limit encountered. Retrying in %s seconds...",
+                    wait,
+                )
+                await asyncio.sleep(wait)
+            except OpenAIError as e:
+                logger.error("OpenAI API error: %s", e)
+                return f"[Error generating response: {e}]"
+            except Exception as e:  # pragma: no cover - unexpected
+                logger.error("Unexpected error generating OpenAI response: %s", e)
+                return f"[Error generating response: {e}]"
+        logger.error("Failed to generate OpenAI response after %s attempts", self.MAX_RETRIES)
+        return "[Error generating response: retry limit exceeded]"
 
     async def _generate_anthropic_response(
         self,
@@ -98,25 +122,41 @@ class ResponseGenerator:
         conversation_memory: ConversationMemory,
         system_prompt: str,
     ) -> str:
-        try:
-            messages = [{"role": "system", "content": system_prompt}]
-            messages.extend(conversation_memory.get_formatted_messages())
-            response = await asyncio.to_thread(
-                lambda: requests.post(
-                    "http://localhost:3000/v1/chat/completions",
-                    json={"messages": messages},
-                    headers={
-                        "Authorization": f"Bearer {self.world_interface_key}",
-                        "Content-Type": "application/json",
-                    },
-                    timeout=30,
+        messages = [{"role": "system", "content": system_prompt}]
+        messages.extend(conversation_memory.get_formatted_messages())
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                response = await asyncio.to_thread(
+                    lambda: requests.post(
+                        "http://localhost:3000/v1/chat/completions",
+                        json={"messages": messages},
+                        headers={
+                            "Authorization": f"Bearer {self.world_interface_key}",
+                            "Content-Type": "application/json",
+                        },
+                        timeout=30,
+                    )
                 )
-            )
-            response.raise_for_status()
-            return response.json()["choices"][0]["message"]["content"]
-        except Exception as e:
-            logger.error("Error generating CLI response: %s", e)
-            return f"[Error generating response: {e}]"
+                response.raise_for_status()
+                return response.json()["choices"][0]["message"]["content"]
+            except requests.exceptions.HTTPError as e:
+                if getattr(e.response, "status_code", None) == 429:
+                    wait = 2 ** attempt
+                    logger.warning(
+                        "CLI API rate limited. Retrying in %s seconds...", wait
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                logger.error("HTTP error from CLI API: %s", e)
+                return f"[Error generating response: {e}]"
+            except requests.exceptions.RequestException as e:
+                logger.error("Request to CLI API failed: %s", e)
+                return f"[Error generating response: {e}]"
+            except Exception as e:  # pragma: no cover - unexpected
+                logger.error("Unexpected error generating CLI response: %s", e)
+                return f"[Error generating response: {e}]"
+        logger.error("Failed to generate CLI response after %s attempts", self.MAX_RETRIES)
+        return "[Error generating response: retry limit exceeded]"
 
     def _generate_human_response(self) -> str:
         return Prompt.ask("\n[Human Input]")

--- a/tests/test_response_generator.py
+++ b/tests/test_response_generator.py
@@ -1,0 +1,82 @@
+import types
+import asyncio
+
+import requests
+import pytest
+
+from conversation_memory import ConversationMemory
+from model_registry import ModelConfig, ModelProvider
+from response_generator import ResponseGenerator, OpenAIError, RateLimitError
+
+
+class DummyRegistry:
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def get_model(self, name):
+        return self.cfg
+
+
+@pytest.mark.asyncio
+async def test_openai_rate_limit_retry(monkeypatch):
+    async def no_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    class DummyRateLimit(RateLimitError):
+        pass
+
+    class DummyOpenAIError(OpenAIError):
+        pass
+
+    dummy_client = types.SimpleNamespace()
+    attempts = {"n": 0}
+
+    def create(**_):
+        if attempts["n"] == 0:
+            attempts["n"] += 1
+            raise DummyRateLimit("rate limit")
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))]
+        )
+
+    dummy_client.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+
+    cfg = ModelConfig(api_name="dummy", client=dummy_client, provider=ModelProvider.OPENAI)
+    gen = ResponseGenerator(DummyRegistry(cfg))
+    result = await gen.generate_response("dummy", ConversationMemory(), "sys")
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_cli_http_retry(monkeypatch):
+    async def no_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    attempts = {"n": 0}
+
+    def fake_post(*_, **__):
+        attempts["n"] += 1
+
+        class Resp:
+            def __init__(self, status):
+                self.status_code = status
+
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    raise requests.exceptions.HTTPError(response=self)
+
+            def json(self):
+                return {"choices": [{"message": {"content": "cli"}}]}
+
+        return Resp(429 if attempts["n"] == 1 else 200)
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    cfg = ModelConfig(api_name="dummy", client=None, provider=ModelProvider.CLI)
+    gen = ResponseGenerator(DummyRegistry(cfg))
+    result = await gen.generate_response("dummy", ConversationMemory(), "sys")
+    assert result == "cli"


### PR DESCRIPTION
## Summary
- refine error handling in `ResponseGenerator`
- add retry logic for OpenAI rate limit and CLI HTTP 429 errors
- cover new branches with unit tests

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*