### PR TITLE
Add provider interface classes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,9 @@ High level interface that manages the conversation loop. It loads configuration,
 ## ModelRegistry
 Loads model definitions from the configuration file and initializes API clients for each provider.
 
+## ModelProviderInterface
+Abstract base class for model providers. Concrete implementations for OpenAI, Anthropic, CLI, and human input expose a shared `generate_response` method. The `ResponseGenerator` relies on this interface so new providers can be added with minimal changes.
+
 ## ResponseGenerator
 Handles calling the underlying model APIs (OpenAI, Anthropic, CLI or human input) to generate responses based on the conversation history.
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,22 @@
 """Entry point for the AI Orchestrator CLI."""
 from cli import run_cli
 
+# Re-export frequently used classes for convenience and tests
+from conversation_memory import (
+    ConversationMemory,
+    Message,
+    MessageContent,
+    TokenLimitStrategy,
+)
+from model_registry import (
+    ConfigurationManager,
+    ModelConfig,
+    ModelProvider,
+    ModelRegistry,
+    ModelRole,
+)
+from response_generator import ResponseGenerator
+
 
 if __name__ == "__main__":
     run_cli()

--- a/model_providers.py
+++ b/model_providers.py
@@ -1,0 +1,116 @@
+# coding: utf-8
+"""Provider abstractions used by ResponseGenerator."""
+from __future__ import annotations
+
+import asyncio
+import os
+import requests
+from abc import ABC, abstractmethod
+from typing import Any
+
+from rich.prompt import Prompt
+
+from conversation_memory import ConversationMemory
+from model_registry import ModelConfig
+
+
+class ModelProviderInterface(ABC):
+    """Abstract interface for model providers."""
+
+    @staticmethod
+    def build_messages(system_prompt: str, memory: ConversationMemory) -> list[dict[str, Any]]:
+        """Return messages formatted for API calls."""
+        messages = [{"role": "system", "content": system_prompt}]
+        messages.extend(memory.get_formatted_messages())
+        return messages
+
+    @abstractmethod
+    async def generate_response(
+        self,
+        model_config: ModelConfig,
+        conversation_memory: ConversationMemory,
+        system_prompt: str,
+    ) -> str:
+        """Return a response from the model."""
+        raise NotImplementedError
+
+
+class OpenAIProvider(ModelProviderInterface):
+    """Generate responses using the OpenAI API."""
+
+    async def generate_response(
+        self, model_config: ModelConfig, conversation_memory: ConversationMemory, system_prompt: str
+    ) -> str:
+        try:
+            messages = self.build_messages(system_prompt, conversation_memory)
+            response = await asyncio.to_thread(
+                model_config.client.chat.completions.create,
+                model=model_config.api_name,
+                messages=messages,
+                temperature=model_config.temperature,
+                max_tokens=model_config.max_response_tokens,
+                **model_config.custom_parameters,
+            )
+            return response.choices[0].message.content
+        except Exception as e:  # pragma: no cover - API call
+            return f"[Error generating response: {e}]"
+
+
+class AnthropicProvider(ModelProviderInterface):
+    """Generate responses using the Anthropic API."""
+
+    async def generate_response(
+        self, model_config: ModelConfig, conversation_memory: ConversationMemory, system_prompt: str
+    ) -> str:
+        try:
+            messages = conversation_memory.get_formatted_messages()
+            response = await asyncio.to_thread(
+                model_config.client.messages.create,
+                model=model_config.api_name,
+                system=system_prompt,
+                messages=messages,
+                temperature=model_config.temperature,
+                max_tokens=model_config.max_response_tokens,
+                **model_config.custom_parameters,
+            )
+            return response.content[0].text
+        except Exception as e:  # pragma: no cover - API call
+            return f"[Error generating response: {e}]"
+
+
+class CLIProvider(ModelProviderInterface):
+    """Generate responses by forwarding to a local CLI service."""
+
+    def __init__(self) -> None:
+        self.world_interface_key = os.getenv("WORLD_INTERFACE_KEY")
+
+    async def generate_response(
+        self, model_config: ModelConfig, conversation_memory: ConversationMemory, system_prompt: str
+    ) -> str:
+        try:
+            messages = self.build_messages(system_prompt, conversation_memory)
+            response = await asyncio.to_thread(
+                lambda: requests.post(
+                    "http://localhost:3000/v1/chat/completions",
+                    json={"messages": messages},
+                    headers={
+                        "Authorization": f"Bearer {self.world_interface_key}",
+                        "Content-Type": "application/json",
+                    },
+                    timeout=30,
+                )
+            )
+            response.raise_for_status()
+            return response.json()["choices"][0]["message"]["content"]
+        except Exception as e:  # pragma: no cover - API call
+            return f"[Error generating response: {e}]"
+
+
+class HumanProvider(ModelProviderInterface):
+    """Obtain responses from a human participant."""
+
+    async def generate_response(
+        self, model_config: ModelConfig, conversation_memory: ConversationMemory, system_prompt: str
+    ) -> str:
+        return await asyncio.to_thread(Prompt.ask, "\n[Human Input]")
+

--- a/model_registry.py
+++ b/model_registry.py
@@ -12,6 +12,13 @@ from dotenv import load_dotenv
 import yaml
 
 from conversation_memory import TokenLimitStrategy
+from model_providers import (
+    AnthropicProvider,
+    CLIProvider,
+    HumanProvider,
+    ModelProviderInterface,
+    OpenAIProvider,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +103,12 @@ class ModelRegistry:
         load_dotenv()
         self.config_manager = config_manager
         self.models: Dict[str, ModelConfig] = {}
+        self.providers: dict[ModelProvider, ModelProviderInterface] = {
+            ModelProvider.OPENAI: OpenAIProvider(),
+            ModelProvider.ANTHROPIC: AnthropicProvider(),
+            ModelProvider.CLI: CLIProvider(),
+            ModelProvider.HUMAN: HumanProvider(),
+        }
         self._initialize_models()
 
     def _initialize_models(self) -> None:
@@ -205,3 +218,6 @@ class ModelRegistry:
 
     def list_available_models(self) -> List[str]:
         return list(self.models.keys())
+
+    def get_provider(self, provider: ModelProvider) -> ModelProviderInterface:
+        return self.providers[provider]

--- a/response_generator.py
+++ b/response_generator.py
@@ -1,14 +1,10 @@
-"""Generate responses from various AI providers."""
-import asyncio
-import os
-import requests
+"""Generate responses from various providers."""
 import logging
 from typing import Optional
 
-from rich.prompt import Prompt
-
 from conversation_memory import ConversationMemory
 from model_registry import ModelRegistry, ModelConfig, ModelProvider
+from model_providers import ModelProviderInterface
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +14,7 @@ class ResponseGenerator:
 
     def __init__(self, registry: ModelRegistry) -> None:
         self.registry = registry
-        self.world_interface_key = os.getenv("WORLD_INTERFACE_KEY")
+        self.providers = registry.providers
 
     async def generate_response(
         self,
@@ -32,91 +28,9 @@ class ResponseGenerator:
 
         effective_prompt = system_prompt or model_config.system_prompt
 
-        if model_config.provider == ModelProvider.OPENAI:
-            return await self._generate_openai_response(
-                model_config, conversation_memory, effective_prompt
-            )
-        if model_config.provider == ModelProvider.ANTHROPIC:
-            return await self._generate_anthropic_response(
-                model_config, conversation_memory, effective_prompt
-            )
-        if model_config.provider == ModelProvider.CLI:
-            return await self._generate_cli_response(
-                model_config, conversation_memory, effective_prompt
-            )
-        if model_config.provider == ModelProvider.HUMAN:
-            return self._generate_human_response()
-        raise ValueError(f"Unsupported provider: {model_config.provider}")
-
-    async def _generate_openai_response(
-        self,
-        model_config: ModelConfig,
-        conversation_memory: ConversationMemory,
-        system_prompt: str,
-    ) -> str:
-        try:
-            messages = [{"role": "system", "content": system_prompt}]
-            messages.extend(conversation_memory.get_formatted_messages())
-            response = await asyncio.to_thread(
-                model_config.client.chat.completions.create,
-                model=model_config.api_name,
-                messages=messages,
-                temperature=model_config.temperature,
-                max_tokens=model_config.max_response_tokens,
-                **model_config.custom_parameters,
-            )
-            return response.choices[0].message.content
-        except Exception as e:
-            logger.error("Error generating OpenAI response: %s", e)
-            return f"[Error generating response: {e}]"
-
-    async def _generate_anthropic_response(
-        self,
-        model_config: ModelConfig,
-        conversation_memory: ConversationMemory,
-        system_prompt: str,
-    ) -> str:
-        try:
-            messages = conversation_memory.get_formatted_messages()
-            response = await asyncio.to_thread(
-                model_config.client.messages.create,
-                model=model_config.api_name,
-                system=system_prompt,
-                messages=messages,
-                temperature=model_config.temperature,
-                max_tokens=model_config.max_response_tokens,
-                **model_config.custom_parameters,
-            )
-            return response.content[0].text
-        except Exception as e:
-            logger.error("Error generating Anthropic response: %s", e)
-            return f"[Error generating response: {e}]"
-
-    async def _generate_cli_response(
-        self,
-        model_config: ModelConfig,
-        conversation_memory: ConversationMemory,
-        system_prompt: str,
-    ) -> str:
-        try:
-            messages = [{"role": "system", "content": system_prompt}]
-            messages.extend(conversation_memory.get_formatted_messages())
-            response = await asyncio.to_thread(
-                lambda: requests.post(
-                    "http://localhost:3000/v1/chat/completions",
-                    json={"messages": messages},
-                    headers={
-                        "Authorization": f"Bearer {self.world_interface_key}",
-                        "Content-Type": "application/json",
-                    },
-                    timeout=30,
-                )
-            )
-            response.raise_for_status()
-            return response.json()["choices"][0]["message"]["content"]
-        except Exception as e:
-            logger.error("Error generating CLI response: %s", e)
-            return f"[Error generating response: {e}]"
-
-    def _generate_human_response(self) -> str:
-        return Prompt.ask("\n[Human Input]")
+        provider = self.providers.get(model_config.provider)
+        if not provider:
+            raise ValueError(f"Unsupported provider: {model_config.provider}")
+        return await provider.generate_response(
+            model_config, conversation_memory, effective_prompt
+        )


### PR DESCRIPTION
## Summary
- introduce `ModelProviderInterface` base class with concrete implementations for OpenAI, Anthropic, CLI and Human providers
- refactor `ResponseGenerator` and `ModelRegistry` to use provider interfaces
- expose common classes from `main.py` for tests
- document provider interface in API docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`