### PR TITLE
Add plugin manager with hook system

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ python main.py --models creative-gpt logical-claude mediator-claude
 python main.py --log-folder ./my_conversations
 ```
 
+## Plugins
+
+The orchestrator can be extended via plugins. List plugin modules under the `plugins` key in your configuration file or install packages that expose an entry point in the `aidirector.plugins` group. See [docs/plugins.md](docs/plugins.md) for details.
+
 ## API Reference
 
 The AI Orchestrator exposes several key classes:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,3 +82,7 @@ logging:
   save_media: true
   metrics_tracking: true
   anonymize_data: false
+
+# Optional plugins
+plugins:
+  - my_package.my_plugin

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,3 +37,14 @@ Control log output under `logging`:
 - `anonymize_data` – remove personal information from logs.
 
 Use the example configuration file (`config.example.yaml`) as a starting point and modify the fields that apply to your setup.
+
+## Plugins
+
+Optional plugins can be loaded by listing module paths under the `plugins` key. For example:
+
+```yaml
+plugins:
+  - my_package.my_plugin
+```
+
+Plugins can also be provided by installed packages using the `aidirector.plugins` entry point. See [plugins.md](plugins.md) for details.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,38 @@
+# Plugin System
+
+AI Orchestrator can be extended with custom plugins. A plugin is a regular Python module that exposes hook functions. The `PluginManager` loads plugins and calls hooks during a run.
+
+## Creating a Plugin
+
+Create a module and define functions matching the hooks you want to implement:
+
+```python
+# my_package/my_plugin.py
+
+def on_init(orchestrator):
+    print("orchestrator initialised")
+
+def message(actor, message):
+    # inspect or modify messages
+    pass
+```
+
+## Enabling Plugins
+
+Plugins may be loaded in two ways:
+
+1. **Configuration** – list module paths under the `plugins` key in `config.yaml`:
+
+```yaml
+plugins:
+  - my_package.my_plugin
+```
+
+2. **Entry points** – install a package that registers an entry point in the `aidirector.plugins` group. Example using `pyproject.toml`:
+
+```toml
+[project.entry-points."aidirector.plugins"]
+my-plugin = "my_package.my_plugin"
+```
+
+After enabling, hooks can be triggered using `PluginManager.run_hook(<hook_name>, *args, **kwargs)`.

--- a/model_registry.py
+++ b/model_registry.py
@@ -88,6 +88,11 @@ class ConfigurationManager:
     def get_logging_config(self) -> Dict[str, Any]:
         return self.config.get("logging", {})
 
+    def get_plugins(self) -> List[str]:
+        """Return plugin modules configured in the YAML file."""
+        plugins = self.config.get("plugins", [])
+        return plugins if isinstance(plugins, list) else []
+
 
 class ModelRegistry:
     """Registry for AI models with initialization of clients."""

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -1,0 +1,57 @@
+"""Plugin loading and hook execution utilities."""
+import logging
+import importlib
+from importlib import metadata
+from typing import Any, List
+
+from model_registry import ConfigurationManager
+
+logger = logging.getLogger(__name__)
+
+
+class PluginManager:
+    """Load optional plugins and execute hook functions."""
+
+    def __init__(self, config_manager: ConfigurationManager) -> None:
+        self.plugins: List[Any] = []
+        self._load_from_config(config_manager)
+        self._load_from_entry_points()
+
+    def _load_from_config(self, config_manager: ConfigurationManager) -> None:
+        for module_path in getattr(config_manager, "get_plugins", lambda: [])():
+            try:
+                module = importlib.import_module(module_path)
+                self.plugins.append(module)
+                logger.info("Loaded plugin %s from config", module_path)
+            except Exception as e:  # pragma: no cover - logging only
+                logger.warning("Failed to load plugin %s: %s", module_path, e)
+
+    def _load_from_entry_points(self) -> None:
+        try:
+            try:
+                eps = metadata.entry_points(group="aidirector.plugins")
+            except TypeError:  # pragma: no cover - older Python
+                eps = metadata.entry_points().get("aidirector.plugins", [])
+        except Exception:  # pragma: no cover - metadata failure
+            eps = []
+        for ep in eps:
+            try:
+                plugin = ep.load()
+                self.plugins.append(plugin)
+                logger.info("Loaded plugin %s from entry point", ep.name)
+            except Exception as e:  # pragma: no cover - logging only
+                logger.warning("Failed to load entry point %s: %s", ep.name, e)
+
+    def run_hook(self, hook_name: str, *args: Any, **kwargs: Any) -> List[Any]:
+        """Execute a hook across all loaded plugins."""
+        results: List[Any] = []
+        for plugin in self.plugins:
+            hook = getattr(plugin, hook_name, None)
+            if callable(hook):
+                try:
+                    results.append(hook(*args, **kwargs))
+                except Exception as e:  # pragma: no cover - runtime errors
+                    logger.error(
+                        "Error in plugin %s during hook %s: %s", plugin, hook_name, e
+                    )
+        return results

--- a/tests/sample_plugin.py
+++ b/tests/sample_plugin.py
@@ -1,0 +1,8 @@
+"""Simple plugin used for testing."""
+
+called = {}
+
+def sample_hook(arg, *, kw=None):
+    called['arg'] = arg
+    called['kw'] = kw
+    return 'ok'

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import importlib
+from plugin_manager import PluginManager
+
+class DummyConfig:
+    def __init__(self, plugins=None):
+        self._plugins = plugins or []
+
+    def get_plugins(self):
+        return self._plugins
+
+
+def test_load_from_config():
+    cfg = DummyConfig(plugins=["tests.sample_plugin"])
+    pm = PluginManager(cfg)
+    assert any(getattr(p, "sample_hook", None) for p in pm.plugins)
+    result = pm.run_hook("sample_hook", 1, kw=2)
+    assert result == ["ok"]
+    from tests import sample_plugin
+    assert sample_plugin.called == {"arg": 1, "kw": 2}
+
+
+def test_load_from_entry_points(monkeypatch):
+    plugin_module = SimpleNamespace(hello=lambda: "hi")
+
+    class EP:
+        name = "ep"
+        def load(self):
+            return plugin_module
+
+    def fake_entry_points(**kwargs):
+        if kwargs.get("group") == "aidirector.plugins":
+            return [EP()]
+        return []
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    pm = PluginManager(DummyConfig())
+    assert pm.run_hook("hello") == ["hi"]


### PR DESCRIPTION
## Summary
- implement `PluginManager` for loading plugins via configuration or entry points
- allow configuration manager to expose configured plugins
- integrate plugin hooks into `AIOrchestrator`
- document plugin system and configuration
- provide sample plugin and tests for the plugin manager

## Testing
- `python -m py_compile plugin_manager.py`
- `python -m py_compile cli.py`
- `python -m pytest -q` *(fails: No module named pytest)*