### PR TITLE
Add integration and error handling tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,17 @@ For full API documentation, see the [API reference](docs/api.md).
 
 ## Running Tests
 
-The project uses [pytest](https://pytest.org/) for unit tests. To execute the
-test suite, simply run:
+The project uses [pytest](https://pytest.org/) for unit tests. Install the
+testing dependencies with:
 
 ```bash
-pytest
+pip install pytest pytest-cov
+```
+
+To run the suite and measure coverage:
+
+```bash
+pytest --cov
 ```
 
 ## Contributing

--- a/tests/test_integration_flow.py
+++ b/tests/test_integration_flow.py
@@ -1,0 +1,31 @@
+import asyncio
+import cli
+import response_generator
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_full_conversation_flow(monkeypatch, tmp_path):
+    responses = iter([
+        "gpt response", "claude response",
+        "gpt response 2", "claude response 2",
+    ])
+
+    async def fake_generate(self, model_name, conv_mem, system_prompt=None):
+        return next(responses)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "k1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k2")
+    monkeypatch.setattr(response_generator.ResponseGenerator, "generate_response", fake_generate)
+    monkeypatch.setattr(cli.Confirm, "ask", lambda *a, **kw: True)
+    monkeypatch.setattr(cli.ConversationLogger, "log_message", lambda *a, **kw: None)
+    monkeypatch.setattr(cli.console, "print", lambda *a, **kw: None)
+
+    orch = cli.AIOrchestrator(models=["gpt-4", "claude-3"], max_turns=2, log_folder=str(tmp_path))
+    await orch.run_conversation()
+
+    # starter message + 4 generated messages
+    assert len(orch.shared_memory.get_messages()) == 5
+    for name in ["gpt-4", "claude-3"]:
+        assert len(orch.conversation_memories[name].get_messages()) == 3
+

--- a/tests/test_response_generator.py
+++ b/tests/test_response_generator.py
@@ -1,0 +1,53 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+import conversation_memory
+import model_registry
+import response_generator
+
+
+@pytest.mark.asyncio
+async def test_openai_error(monkeypatch):
+    def fail_create(*a, **k):
+        raise RuntimeError("fail")
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=fail_create)))
+    cfg = model_registry.ModelConfig(
+        api_name="gpt-4",
+        client=client,
+        provider=model_registry.ModelProvider.OPENAI,
+    )
+    rg = response_generator.ResponseGenerator(SimpleNamespace(get_model=lambda n: cfg))
+    mem = conversation_memory.ConversationMemory()
+    result = await rg._generate_openai_response(cfg, mem, "sys")
+    assert result.startswith("[Error generating response:")
+
+
+@pytest.mark.asyncio
+async def test_cli_error(monkeypatch):
+    def fail_post(*a, **k):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fail_post)
+
+    cfg = model_registry.ModelConfig(
+        api_name="test-cli",
+        client=None,
+        provider=model_registry.ModelProvider.CLI,
+    )
+    rg = response_generator.ResponseGenerator(SimpleNamespace(get_model=lambda n: cfg))
+    mem = conversation_memory.ConversationMemory()
+    result = await rg._generate_cli_response(cfg, mem, "sys")
+    assert result.startswith("[Error generating response:")
+
+
+@pytest.mark.asyncio
+async def test_unknown_model(monkeypatch):
+    rg = response_generator.ResponseGenerator(SimpleNamespace(get_model=lambda n: None))
+    mem = conversation_memory.ConversationMemory()
+    with pytest.raises(ValueError):
+        await rg.generate_response("missing", mem)
+


### PR DESCRIPTION
## Summary
- add integration test covering a multi-turn conversation flow
- test ResponseGenerator error conditions for OpenAI and CLI models
- document coverage instructions in README

## Testing
- `pytest --cov` *(fails: command not found)*