### PR TITLE
Move dotenv loading to CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
+from dotenv import load_dotenv
 
 from conversation_memory import ConversationMemory, Message, MessageContent
 from model_registry import ConfigurationManager, ModelRegistry, ModelProvider
@@ -193,6 +194,7 @@ class AIOrchestrator:
 
 
 def run_cli() -> None:
+    load_dotenv()
     parser = argparse.ArgumentParser(description="AI Conversation Orchestrator")
     parser.add_argument("--models", nargs="+", default=["gpt-4", "claude-3"], help="Models to include in conversation")
     parser.add_argument("--turns", type=int, default=5, help="Maximum number of conversation turns")

--- a/model_registry.py
+++ b/model_registry.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 
 import openai
 import anthropic
-from dotenv import load_dotenv
 import yaml
 
 from conversation_memory import TokenLimitStrategy
@@ -93,7 +92,6 @@ class ModelRegistry:
     """Registry for AI models with initialization of clients."""
 
     def __init__(self, config_manager: ConfigurationManager) -> None:
-        load_dotenv()
         self.config_manager = config_manager
         self.models: Dict[str, ModelConfig] = {}
         self._initialize_models()


### PR DESCRIPTION
## Summary
- load dotenv once at CLI startup
- remove dotenv loading from model initialization

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*